### PR TITLE
feat: Implement `node-taint` chaos experiment, adding new CRD fields …

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -64,7 +64,7 @@
 ### Node Chaos
 - [x] **node-drain** - Drain nodes temporarily
 - [x] **node-uncordon** - Auto-uncordon nodes after drain experiments complete ✅
-- [ ] **node-taint** - Add taints to nodes
+- [x] **node-taint** - Add taints to nodes
 - [ ] **node-cpu-stress** - Stress node CPU
 - [ ] **node-disk-fill** - Fill node disk space
 

--- a/api/v1alpha1/chaosexperiment_types.go
+++ b/api/v1alpha1/chaosexperiment_types.go
@@ -46,7 +46,7 @@ type ChaosExperimentSpec struct {
 
 	// Action specifies the chaos action to perform
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=pod-kill;pod-delay;node-drain;pod-cpu-stress;pod-memory-stress;pod-failure;pod-network-loss;pod-network-corruption;pod-disk-fill;pod-restart;network-partition
+	// +kubebuilder:validation:Enum=pod-kill;pod-delay;node-drain;node-taint;pod-cpu-stress;pod-memory-stress;pod-failure;pod-network-loss;pod-network-corruption;pod-disk-fill;pod-restart;network-partition
 	Action string `json:"action"`
 
 	// Namespace specifies the target namespace for chaos experiments
@@ -267,6 +267,20 @@ type ChaosExperimentSpec struct {
 	// +kubebuilder:validation:Pattern="^([0-9]+(s|m|h))+$"
 	// +optional
 	RestartInterval string `json:"restartInterval,omitempty"`
+
+	// TaintKey specifies the key of the taint to apply to nodes (for node-taint)
+	// +optional
+	TaintKey string `json:"taintKey,omitempty"`
+
+	// TaintValue specifies the value of the taint to apply to nodes (for node-taint)
+	// +optional
+	TaintValue string `json:"taintValue,omitempty"`
+
+	// TaintEffect specifies the effect of the taint (for node-taint)
+	// +kubebuilder:validation:Enum=NoSchedule;PreferNoSchedule;NoExecute
+	// +kubebuilder:default=NoSchedule
+	// +optional
+	TaintEffect string `json:"taintEffect,omitempty"`
 }
 
 // TimeWindowType defines the time window mode for experiments.
@@ -358,6 +372,11 @@ type ChaosExperimentStatus struct {
 	// Used for auto-uncordon when the experiment completes
 	// +optional
 	CordonedNodes []string `json:"cordonedNodes,omitempty"`
+
+	// TaintedNodes tracks nodes that were tainted by this experiment
+	// Used for removing taints when the experiment completes
+	// +optional
+	TaintedNodes []string `json:"taintedNodes,omitempty"`
 
 	// Conditions represents the latest available observations of the experiment
 	// +optional

--- a/api/v1alpha1/chaosexperiment_webhook.go
+++ b/api/v1alpha1/chaosexperiment_webhook.go
@@ -171,6 +171,19 @@ func (w *ChaosExperimentWebhook) validateCrossFieldConstraints(spec *ChaosExperi
 		}
 	}
 
+	// node-taint action requires duration, taintKey, and taintEffect
+	if spec.Action == "node-taint" {
+		if spec.Duration == "" {
+			return fmt.Errorf("duration is required for node-taint action")
+		}
+		if spec.TaintKey == "" {
+			return fmt.Errorf("taintKey must be specified for node-taint action")
+		}
+		if spec.TaintEffect == "" {
+			return fmt.Errorf("taintEffect must be specified for node-taint action")
+		}
+	}
+
 	// Validate duration format if provided
 	if spec.Duration != "" {
 		if err := ValidateDurationFormat(spec.Duration); err != nil {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -291,6 +291,11 @@ func (in *ChaosExperimentStatus) DeepCopyInto(out *ChaosExperimentStatus) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.TaintedNodes != nil {
+		in, out := &in.TaintedNodes, &out.TaintedNodes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]v1.Condition, len(*in))

--- a/config/crd/bases/chaos.gushchin.dev_chaosexperimenthistories.yaml
+++ b/config/crd/bases/chaos.gushchin.dev_chaosexperimenthistories.yaml
@@ -214,6 +214,7 @@ spec:
                     - pod-kill
                     - pod-delay
                     - node-drain
+                    - node-taint
                     - pod-cpu-stress
                     - pod-memory-stress
                     - pod-failure
@@ -432,6 +433,23 @@ spec:
                       resources
                     minProperties: 1
                     type: object
+                  taintEffect:
+                    default: NoSchedule
+                    description: TaintEffect specifies the effect of the taint (for
+                      node-taint)
+                    enum:
+                    - NoSchedule
+                    - PreferNoSchedule
+                    - NoExecute
+                    type: string
+                  taintKey:
+                    description: TaintKey specifies the key of the taint to apply
+                      to nodes (for node-taint)
+                    type: string
+                  taintValue:
+                    description: TaintValue specifies the value of the taint to apply
+                      to nodes (for node-taint)
+                    type: string
                   targetCIDRs:
                     description: |-
                       TargetCIDRs specifies IP ranges to block using CIDR notation (for network-partition)

--- a/config/crd/bases/chaos.gushchin.dev_chaosexperiments.yaml
+++ b/config/crd/bases/chaos.gushchin.dev_chaosexperiments.yaml
@@ -64,6 +64,7 @@ spec:
                 - pod-kill
                 - pod-delay
                 - node-drain
+                - node-taint
                 - pod-cpu-stress
                 - pod-memory-stress
                 - pod-failure
@@ -279,6 +280,22 @@ spec:
                 description: Selector specifies the label selector for target resources
                 minProperties: 1
                 type: object
+              taintEffect:
+                default: NoSchedule
+                description: TaintEffect specifies the effect of the taint (for node-taint)
+                enum:
+                - NoSchedule
+                - PreferNoSchedule
+                - NoExecute
+                type: string
+              taintKey:
+                description: TaintKey specifies the key of the taint to apply to nodes
+                  (for node-taint)
+                type: string
+              taintValue:
+                description: TaintValue specifies the value of the taint to apply
+                  to nodes (for node-taint)
+                type: string
               targetCIDRs:
                 description: |-
                   TargetCIDRs specifies IP ranges to block using CIDR notation (for network-partition)
@@ -507,6 +524,13 @@ spec:
                 description: StartTime indicates when the experiment started running
                 format: date-time
                 type: string
+              taintedNodes:
+                description: |-
+                  TaintedNodes tracks nodes that were tainted by this experiment
+                  Used for removing taints when the experiment completes
+                items:
+                  type: string
+                type: array
             type: object
         required:
         - spec

--- a/config/samples/chaos_v1alpha1_chaosexperiment_node_taint.yaml
+++ b/config/samples/chaos_v1alpha1_chaosexperiment_node_taint.yaml
@@ -1,0 +1,53 @@
+apiVersion: chaos.gushchin.dev/v1alpha1
+kind: ChaosExperiment
+metadata:
+  labels:
+    app.kubernetes.io/name: chaosexperiment
+    app.kubernetes.io/managed-by: kustomize
+  name: node-taint-sample
+spec:
+  # ACTION: node-taint
+  # SIMULATES: Node becoming unschedulable or affecting running pods via taints
+  # BEHAVIOR: Applies a specified taint to the selected nodes
+  action: node-taint
+  
+  # Target nodes in this namespace context (though nodes are cluster-scoped)
+  namespace: default
+  
+  # Select which nodes to affect
+  # If empty or not provided, affects all nodes
+  selector:
+    # Example: only target nodes with a specific label
+    # node-role.kubernetes.io/worker: "true"
+    
+  # How many matching nodes to taint (default is 1)
+  count: 1
+  
+  # DURATION (Required for node-taint)
+  # How long the node should remain tainted before being automatically untainted.
+  # Formats: "10s", "1m", "1h"
+  duration: 2m
+  
+  # TAINT KEY (Required)
+  # The key of the taint to apply
+  taintKey: chaos.gushchin.dev/taint
+  
+  # TAINT VALUE (Optional)
+  # The value of the taint to apply
+  taintValue: "true"
+  
+  # TAINT EFFECT (Required)
+  # The effect of the taint. Valid values: NoSchedule, PreferNoSchedule, NoExecute
+  # Default if not specified: NoSchedule
+  taintEffect: NoSchedule
+  
+  # --- SAFETY FEATURES ---
+  
+  # MAX PERCENTAGE (Optional)
+  # Protects against selecting too many nodes if count is high
+  # e.g., never affect more than 20% of matching nodes
+  maxPercentage: 20
+  
+  # DRY RUN (Optional)
+  # Set to true to see which nodes would be tainted without actually doing it
+  dryRun: false

--- a/internal/controller/chaosexperiment_controller.go
+++ b/internal/controller/chaosexperiment_controller.go
@@ -28,10 +28,12 @@ import (
 
 	"github.com/robfig/cron/v3"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -173,6 +175,8 @@ func (r *ChaosExperimentReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return r.handlePodDelay(ctx, &exp)
 	case "node-drain":
 		return r.handleNodeDrain(ctx, &exp)
+	case "node-taint":
+		return r.handleNodeTaint(ctx, &exp)
 	case "pod-cpu-stress":
 		return r.handlePodCPUStress(ctx, &exp)
 	case "pod-memory-stress":
@@ -979,6 +983,227 @@ func (r *ChaosExperimentReconciler) uncordonNode(ctx context.Context, nodeName s
 	return nil
 }
 
+// handleNodeTaint taints nodes matching the selector
+func (r *ChaosExperimentReconciler) handleNodeTaint(ctx context.Context, exp *chaosv1alpha1.ChaosExperiment) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+	startTime := time.Now()
+
+	// Track active experiments
+	chaosmetrics.ActiveExperiments.WithLabelValues("node-taint").Inc()
+	defer chaosmetrics.ActiveExperiments.WithLabelValues("node-taint").Dec()
+
+	// Validate required fields
+	if exp.Spec.TaintKey == "" || exp.Spec.TaintEffect == "" {
+		return r.handleExperimentFailure(ctx, exp, "TaintKey and TaintEffect must be specified")
+	}
+
+	// List nodes by selector
+	nodeList := &corev1.NodeList{}
+	selector := labels.SelectorFromSet(exp.Spec.Selector)
+	if err := r.List(ctx, nodeList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
+		log.Error(err, "Failed to list nodes")
+		exp.Status.Message = "Error: Failed to list nodes"
+		_ = r.Status().Update(ctx, exp)
+		return ctrl.Result{}, err
+	}
+
+	if len(nodeList.Items) == 0 {
+		log.Info("No nodes found for selector", "selector", exp.Spec.Selector)
+		exp.Status.Message = "No nodes found matching selector"
+		_ = r.Status().Update(ctx, exp)
+		return ctrl.Result{RequeueAfter: time.Minute}, nil
+	}
+
+	// Handle dry-run mode for nodes
+	if exp.Spec.DryRun {
+		count := exp.Spec.Count
+		if count <= 0 {
+			count = 1
+		}
+		if count > len(nodeList.Items) {
+			count = len(nodeList.Items)
+		}
+
+		nodeNames := []string{}
+		for i := 0; i < count && i < len(nodeList.Items); i++ {
+			nodeNames = append(nodeNames, nodeList.Items[i].Name)
+		}
+
+		now := metav1.Now()
+		exp.Status.LastRunTime = &now
+		exp.Status.Message = fmt.Sprintf("DRY RUN: Would taint %d node(s) with %s: %v", count, exp.Spec.TaintKey, nodeNames)
+		exp.Status.Phase = "Completed"
+
+		if err := r.Status().Update(ctx, exp); err != nil {
+			log.Error(err, "Failed to update ChaosExperiment status")
+			return ctrl.Result{}, err
+		}
+
+		log.Info("Dry run completed", "action", "node-taint", "wouldAffect", count, "nodes", nodeNames)
+		return ctrl.Result{}, nil
+	}
+
+	// Shuffle the list of nodes
+	rand.Shuffle(len(nodeList.Items), func(i, j int) {
+		nodeList.Items[i], nodeList.Items[j] = nodeList.Items[j], nodeList.Items[i]
+	})
+
+	// Determine how many nodes to taint
+	taintCount := exp.Spec.Count
+	if taintCount <= 0 {
+		taintCount = 1 // Default to 1 if not specified or invalid
+	}
+	if taintCount > len(nodeList.Items) {
+		taintCount = len(nodeList.Items)
+	}
+
+	// Taint selected nodes
+	taintedNodes := []string{}
+	newlyTaintedNodes := []string{}
+	for i := 0; i < taintCount; i++ {
+		node := &nodeList.Items[i]
+		log.Info("Tainting node", "node", node.Name, "key", exp.Spec.TaintKey, "value", exp.Spec.TaintValue, "effect", exp.Spec.TaintEffect)
+
+		// Taint the node
+		wasAlreadyTainted, err := r.taintNode(ctx, node, exp.Spec.TaintKey, exp.Spec.TaintValue, exp.Spec.TaintEffect)
+		if err != nil {
+			log.Error(err, "Failed to taint node", "node", node.Name)
+			continue
+		}
+
+		// Track nodes that we tainted (not ones that were already tainted)
+		if !wasAlreadyTainted {
+			newlyTaintedNodes = append(newlyTaintedNodes, node.Name)
+		}
+
+		// Emit event on the affected node
+		r.Recorder.Eventf(node, corev1.EventTypeWarning, "ChaosNodeTaint",
+			"Node tainted with %s=%s:%s by chaos experiment %s", exp.Spec.TaintKey, exp.Spec.TaintValue, exp.Spec.TaintEffect, exp.Name)
+
+		taintedNodes = append(taintedNodes, node.Name)
+	}
+
+	// Update status to track newly tainted nodes for later untaint
+	if len(newlyTaintedNodes) > 0 {
+		// Append newly tainted nodes to the existing list (avoid duplicates)
+		existingNodes := make(map[string]bool)
+		for _, nodeName := range exp.Status.TaintedNodes {
+			existingNodes[nodeName] = true
+		}
+		for _, nodeName := range newlyTaintedNodes {
+			if !existingNodes[nodeName] {
+				exp.Status.TaintedNodes = append(exp.Status.TaintedNodes, nodeName)
+			}
+		}
+	}
+
+	// Update status
+	now := metav1.Now()
+	exp.Status.LastRunTime = &now
+	status := statusSuccess
+	if len(taintedNodes) > 0 {
+		exp.Status.Message = fmt.Sprintf("Successfully tainted %d node(s): %v", len(taintedNodes), taintedNodes)
+	} else {
+		exp.Status.Message = "Failed to taint any nodes"
+		status = statusFailure
+	}
+	if err := r.Status().Update(ctx, exp); err != nil {
+		log.Error(err, "Failed to update ChaosExperiment status")
+		return ctrl.Result{}, err
+	}
+
+	// Record metrics
+	duration := time.Since(startTime).Seconds()
+	chaosmetrics.ExperimentsTotal.WithLabelValues("node-taint", exp.Spec.Namespace, status).Inc()
+	chaosmetrics.ExperimentDuration.WithLabelValues("node-taint", exp.Spec.Namespace).Observe(duration)
+	chaosmetrics.ResourcesAffected.WithLabelValues("node-taint", exp.Spec.Namespace, exp.Name).Set(float64(len(taintedNodes)))
+
+	// Create history record
+	affectedResources := buildResourceReferences("tainted", "", taintedNodes, "Node")
+	var errorDetails *chaosv1alpha1.ErrorDetails
+	if status == statusFailure {
+		errorDetails = &chaosv1alpha1.ErrorDetails{
+			Message:       exp.Status.Message,
+			FailureReason: "ExecutionError",
+		}
+	}
+	if err := r.createHistoryRecord(ctx, exp, status, affectedResources, startTime, errorDetails); err != nil {
+		log.Error(err, "Failed to create history record")
+		// Don't fail the experiment if history recording fails
+	}
+
+	return ctrl.Result{RequeueAfter: time.Minute}, nil
+}
+
+// taintNode adds a taint to the node if it doesn't already have it
+// Returns (wasAlreadyTainted bool, error)
+func (r *ChaosExperimentReconciler) taintNode(ctx context.Context, node *corev1.Node, key, value, effect string) (bool, error) {
+	taintEffect := corev1.TaintEffect(effect)
+
+	// Check if already tainted
+	for _, t := range node.Spec.Taints {
+		if t.Key == key && t.Effect == taintEffect {
+			return true, nil // Already tainted with the same key and effect
+		}
+	}
+
+	node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
+		Key:    key,
+		Value:  value,
+		Effect: taintEffect,
+	})
+
+	if err := r.Update(ctx, node); err != nil {
+		return false, fmt.Errorf("failed to taint node: %w", err)
+	}
+
+	return false, nil
+}
+
+// untaintNode removes a specific taint from a node
+func (r *ChaosExperimentReconciler) untaintNode(ctx context.Context, nodeName, key, effect string) error {
+	log := ctrl.LoggerFrom(ctx)
+	
+	if nodeName == "" {
+		return fmt.Errorf("node name cannot be empty")
+	}
+
+	node := &corev1.Node{}
+	if err := r.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("Node not found for untainting, it might have been removed", "node", nodeName)
+			return nil
+		}
+		return fmt.Errorf("failed to get node %s: %w", nodeName, err)
+	}
+
+	taintEffect := corev1.TaintEffect(effect)
+	newTaints := []corev1.Taint{}
+	found := false
+
+	// Filter out the applied taint
+	for _, t := range node.Spec.Taints {
+		if t.Key == key && t.Effect == taintEffect {
+			found = true
+			continue
+		}
+		newTaints = append(newTaints, t)
+	}
+
+	if !found {
+		log.Info("Node does not have the taint, nothing to remove", "node", nodeName, "key", key)
+		return nil
+	}
+
+	node.Spec.Taints = newTaints
+	if err := r.Update(ctx, node); err != nil {
+		return fmt.Errorf("failed to untaint node %s: %w", nodeName, err)
+	}
+
+	log.Info("Successfully untainted node", "node", nodeName, "key", key)
+	return nil
+}
+
 // drainNode evicts all pods from a node
 func (r *ChaosExperimentReconciler) drainNode(ctx context.Context, node *corev1.Node) error {
 	log := ctrl.LoggerFrom(ctx)
@@ -1308,6 +1533,20 @@ func (r *ChaosExperimentReconciler) checkExperimentLifecycle(ctx context.Context
 			}
 			// Clear the list after uncordoning
 			exp.Status.CordonedNodes = nil
+		}
+
+		// Untaint nodes that were tainted by this experiment (for node-taint action)
+		if exp.Spec.Action == "node-taint" && len(exp.Status.TaintedNodes) > 0 {
+			log.Info("Removing taints from nodes that were tainted by this experiment",
+				"nodes", exp.Status.TaintedNodes)
+			for _, nodeName := range exp.Status.TaintedNodes {
+				if err := r.untaintNode(ctx, nodeName, exp.Spec.TaintKey, exp.Spec.TaintEffect); err != nil {
+					log.Error(err, "Failed to untaint node", "node", nodeName)
+					// Continue with other nodes even if one fails
+				}
+			}
+			// Clear the list after untainting
+			exp.Status.TaintedNodes = nil
 		}
 
 		// Cleanup ephemeral containers for experiments using them (pod-cpu-stress, pod-memory-stress, pod-network-loss, pod-disk-fill)

--- a/internal/controller/chaosexperiment_controller_test.go
+++ b/internal/controller/chaosexperiment_controller_test.go
@@ -197,11 +197,20 @@ var _ = Describe("ChaosExperiment Controller", func() {
 		})
 
 		It("Should skip terminating pods", func() {
+			// Use a unique namespace for this test to avoid race conditions with BeforeEach/AfterEach cleanup
+			uniqueNamespace := "test-term-ns-" + generateShortUID()
+
+			realNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: uniqueNamespace}}
+			Expect(k8sClient.Create(ctx, realNs)).Should(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(ctx, realNs)
+			}()
+
 			By("Creating a terminating pod")
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "terminating-pod",
-					Namespace: targetNamespace,
+					Namespace: uniqueNamespace,
 					Labels: map[string]string{
 						"app": "test-terminating",
 					},
@@ -222,8 +231,8 @@ var _ = Describe("ChaosExperiment Controller", func() {
 
 			By("Adding finalizer to keep pod in Terminating state when deleted")
 			podWithFinalizer := &corev1.Pod{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, podWithFinalizer)).Should(Succeed())
-			podWithFinalizer.Finalizers = append(podWithFinalizer.Finalizers, "chaos-test-finalizer")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: uniqueNamespace}, podWithFinalizer)).Should(Succeed())
+			podWithFinalizer.Finalizers = append(podWithFinalizer.Finalizers, "chaos.gushchin.dev/test-finalizer")
 			Expect(k8sClient.Update(ctx, podWithFinalizer)).Should(Succeed())
 
 			By("Deleting the pod to set DeletionTimestamp")
@@ -237,7 +246,7 @@ var _ = Describe("ChaosExperiment Controller", func() {
 				},
 				Spec: chaosv1alpha1.ChaosExperimentSpec{
 					Action:    "pod-kill",
-					Namespace: targetNamespace,
+					Namespace: uniqueNamespace,
 					Selector: map[string]string{
 						"app": "test-terminating",
 					},


### PR DESCRIPTION
…for taint configuration and controller logic to apply and manage node taints.